### PR TITLE
Update site title and meta tags

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,9 @@
+const metaTags = require('./src/data/website/meta-tags')
+
 module.exports = {
   siteMetadata: {
-    title: 'Gatsby Default Starter',
+    title: 'Virgil Music',
+    metaTags: metaTags,
   },
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/src/data/website/meta-tags.js
+++ b/src/data/website/meta-tags.js
@@ -1,0 +1,27 @@
+module.exports = [
+  {
+    name: 'apple-mobile-web-app-title',
+    content: 'Virgil Music',
+  },
+  {
+    name: 'application-name',
+    content: 'Virgil Music',
+  },
+  {
+    name: 'description',
+    content:
+      'Instrumental Progressive Metal',
+  },
+  {
+    name: 'keywords',
+    content: 'Virgil, Virgil Music, Prog, Progressive, Metal',
+  },
+  {
+    name: 'msapplication-TileColor',
+    content: '#666',
+  },
+  {
+    name: 'theme-color',
+    content: '#666',
+  },
+]

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -5,31 +5,38 @@ import Helmet from 'react-helmet'
 import Header from '../components/Header'
 import './index.scss'
 
-const TemplateWrapper = ({ children }) => (
+const IndexLayout = ({ children, data }) => (
   <div>
     <Helmet
-      title="Gatsby Default Starter"
-      meta={[
-        { name: 'description', content: 'Sample' },
-        { name: 'keywords', content: 'sample, something' },
-      ]}
+      meta={data.site.siteMetadata.metaTags}
+      title={data.site.siteMetadata.title}
     />
     <Header />
-    <div
-      style={{
-        margin: '0 auto',
-        maxWidth: 960,
-        padding: '0px 1.0875rem 1.45rem',
-        paddingTop: 0,
-      }}
-    >
+    <div>
       {children()}
     </div>
   </div>
 )
 
-TemplateWrapper.propTypes = {
-  children: PropTypes.func,
+IndexLayout.propTypes = {
+  children: PropTypes.func.isRequired,
+  data: PropTypes.shape({
+    site: PropTypes.object.isRequired,
+  }).isRequired,
 }
 
-export default TemplateWrapper
+export default IndexLayout
+
+export const query = graphql`
+  query IndexLayoutQuery {
+    site {
+      siteMetadata {
+        metaTags {
+          name
+          content
+        }
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
# Overview
* Updates the default meta-tag content. 
* Implements `data > website > meta-tags.js` file to feed `gatsby-config.js`.
* Cleans up the IndexLayout file.