### PR TITLE
Use rgba() over 8 digit hex for header background color

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -19,7 +19,7 @@ const StyledNavbar = styled(Navbar).attrs({
 })
 `
   &&& {
-    background-color: #111111e8;
+    background-color: rgba(17, 17, 17, 0.91);
     font-family: "PT Sans Narrow", sans-serif;
     position: sticky;
   }


### PR DESCRIPTION
Fixes issue on IE, EDGE, Safari where header background color was completely transparent.